### PR TITLE
Provide correct scope 'test' for junit and mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.magnolia</groupId>


### PR DESCRIPTION
Just added a scope for the test dependencies.
The missing scope broke our build, because we rely on a different Mockito version.
